### PR TITLE
fix: audit cleanup — CODEOWNERS, test label, session cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Core code - maintainer only
-/src/ @gavrielc @gabi-simons
-/container/ @gavrielc @gabi-simons
-/groups/ @gavrielc @gabi-simons
-/launchd/ @gavrielc @gabi-simons
-/package.json @gavrielc @gabi-simons
-/package-lock.json @gavrielc @gabi-simons
+/src/ @ridermw
+/container/ @ridermw
+/groups/ @ridermw
+/launchd/ @ridermw
+/package.json @ridermw
+/package-lock.json @ridermw
 
 # Skills - open to contributors
 /.claude/skills/

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,14 @@
+# TODOS
+
+## Port critical NanoClaw bug fixes
+**Priority:** High
+**What:** Review and port applicable bug fixes from NanoClaw upstream PRs.
+**Why:** Known bugs likely affect NanoPilot's stability — message loss, deadlocks, security.
+**PRs to evaluate:** #1576 (message loss), #1623 (stream deadlock), #1640 (stale cache), telegram#95 (self-message loop), telegram#119 (409 reconnect), whatsapp#83 (Baileys logger), gmail#7 (credential exposure).
+**Depends on:** Nothing.
+
+## Fix pre-existing test failures
+**Priority:** Medium
+**What:** Fix 3 test files that fail on main: `container-runtime.test.ts`, `routing.test.ts`, `task-scheduler.test.ts`.
+**Why:** All fail due to `CREDENTIAL_PROXY_HOST` import from `credential-proxy.ts` throwing when `.env` doesn't have the value. From apple-container skill branch code leaking into imports.
+**Depends on:** Nothing.

--- a/scripts/cleanup-sessions.sh
+++ b/scripts/cleanup-sessions.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# Prune stale session artifacts (Copilot SDK state, SDK logs, container logs).
+# Safe to run while NanoPilot is live — active sessions are read from the DB.
+#
+# Usage:  ./scripts/cleanup-sessions.sh [--dry-run]
+#
+# Retention:
+#   Copilot session-state dirs:  7 days  (active session always kept)
+#   Copilot SDK process logs:    3 days
+#   Container run logs:          7 days
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+STORE_DB="$PROJECT_ROOT/store/messages.db"
+SESSIONS_DIR="$PROJECT_ROOT/data/sessions"
+GROUPS_DIR="$PROJECT_ROOT/groups"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+TOTAL_FREED=0
+
+log() { echo "[cleanup] $*"; }
+
+# Check for sqlite3
+if ! command -v sqlite3 &>/dev/null; then
+  log "ERROR: sqlite3 not found. Install it to enable session cleanup."
+  exit 1
+fi
+
+remove() {
+  local target="$1"
+  if $DRY_RUN; then
+    if [ -d "$target" ]; then
+      size=$(du -sk "$target" 2>/dev/null | cut -f1)
+    else
+      size=$(wc -c < "$target" 2>/dev/null || echo 0)
+      size=$((size / 1024))
+    fi
+    TOTAL_FREED=$((TOTAL_FREED + size))
+    log "would remove: $target (${size}K)"
+  else
+    if [ -d "$target" ]; then
+      size=$(du -sk "$target" 2>/dev/null | cut -f1)
+      rm -rf "$target"
+    else
+      size=$(wc -c < "$target" 2>/dev/null || echo 0)
+      size=$((size / 1024))
+      rm -f "$target"
+    fi
+    TOTAL_FREED=$((TOTAL_FREED + size))
+  fi
+}
+
+# --- Collect active session IDs from the database ---
+
+if [ ! -f "$STORE_DB" ]; then
+  log "ERROR: database not found at $STORE_DB"
+  exit 1
+fi
+
+ACTIVE_IDS=$(sqlite3 "$STORE_DB" "SELECT session_id FROM sessions;" 2>/dev/null || true)
+
+is_active() {
+  echo "$ACTIVE_IDS" | grep -qF "$1"
+}
+
+# --- Prune stale Copilot session-state dirs (>7 days, skip active) ---
+
+for group_dir in "$SESSIONS_DIR"/*/; do
+  [ -d "$group_dir" ] || continue
+  session_state_dir="$group_dir/.copilot/session-state"
+  [ -d "$session_state_dir" ] || continue
+
+  for session_dir in "$session_state_dir"/*/; do
+    [ -d "$session_dir" ] || continue
+    # Skip symlinks for safety
+    [ -L "$session_dir" ] && continue
+
+    uuid=$(basename "$session_dir")
+
+    # Never delete the active session
+    if is_active "$uuid"; then
+      continue
+    fi
+
+    # Only delete if the directory is older than 7 days
+    if [ -n "$(find "$session_dir" -maxdepth 0 -mtime +7 2>/dev/null)" ]; then
+      remove "$session_dir"
+    fi
+  done
+done
+
+# --- Prune Copilot SDK process logs (>3 days) ---
+
+for group_dir in "$SESSIONS_DIR"/*/; do
+  logs_dir="$group_dir/.copilot/logs"
+  [ -d "$logs_dir" ] || continue
+  while IFS= read -r -d '' f; do
+    # Skip symlinks for safety
+    [ -L "$f" ] && continue
+    remove "$f"
+  done < <(find "$logs_dir" -type f -not -type l -name "process-*.log" -mtime +3 -print0 2>/dev/null)
+done
+
+# --- Prune container run logs (>7 days) ---
+
+for group_dir in "$GROUPS_DIR"/*/; do
+  logs_dir="$group_dir/logs"
+  [ -d "$logs_dir" ] || continue
+  while IFS= read -r -d '' f; do
+    # Skip symlinks for safety
+    [ -L "$f" ] && continue
+    remove "$f"
+  done < <(find "$logs_dir" -type f -not -type l -name "container-*.log" -mtime +7 -print0 2>/dev/null)
+done
+
+# --- Summary ---
+
+if $DRY_RUN; then
+  log "DRY RUN complete — would free ~${TOTAL_FREED}K"
+else
+  log "Done — freed ~${TOTAL_FREED}K"
+fi

--- a/setup/environment.test.ts
+++ b/setup/environment.test.ts
@@ -95,7 +95,7 @@ describe('credentials detection', () => {
     expect(hasCredentials).toBe(false);
   });
 
-  it('returns false for old Anthropic credentials (regression)', () => {
+  it('returns false for non-Copilot credentials (regression)', () => {
     const content = 'ANTHROPIC_API_KEY=sk-ant-test123\nCLAUDE_CODE_OAUTH_TOKEN=token';
     const hasCredentials =
       /^COPILOT_GITHUB_TOKEN=/m.test(content);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   cleanupOrphans,
   ensureContainerRuntimeRunning,
 } from './container-runtime.js';
+import { startSessionCleanup } from './session-cleanup.js';
 import {
   getAllChats,
   getAllRegisteredGroups,
@@ -543,6 +544,7 @@ async function main(): Promise<void> {
   initDatabase();
   logger.info('Database initialized');
   loadState();
+  startSessionCleanup();
 
   // Fail fast if Copilot token is missing
   if (!COPILOT_GITHUB_TOKEN) {

--- a/src/session-cleanup.test.ts
+++ b/src/session-cleanup.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'child_process';
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockedExecFile = vi.mocked(execFile);
+
+describe('session-cleanup', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('schedules cleanup 30s after startup', async () => {
+    const { startSessionCleanup } = await import('./session-cleanup.js');
+    startSessionCleanup();
+
+    expect(mockedExecFile).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(30_000);
+
+    expect(mockedExecFile).toHaveBeenCalledTimes(1);
+    expect(mockedExecFile).toHaveBeenCalledWith(
+      '/bin/bash',
+      [expect.stringContaining('cleanup-sessions.sh')],
+      { timeout: 60_000 },
+      expect.any(Function),
+    );
+  });
+
+  it('runs cleanup every 24 hours after initial run', async () => {
+    vi.resetModules();
+    const { startSessionCleanup } = await import('./session-cleanup.js');
+    startSessionCleanup();
+
+    // Initial 30s delay
+    vi.advanceTimersByTime(30_000);
+    expect(mockedExecFile).toHaveBeenCalledTimes(1);
+
+    // 24 hours later
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    expect(mockedExecFile).toHaveBeenCalledTimes(2);
+
+    // Another 24 hours
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    expect(mockedExecFile).toHaveBeenCalledTimes(3);
+  });
+
+  it('logs summary on successful cleanup', async () => {
+    vi.resetModules();
+    const { logger } = await import('./logger.js');
+    const { startSessionCleanup } = await import('./session-cleanup.js');
+
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      (cb as Function)(null, '[cleanup] Done — freed ~128K\n');
+      return undefined as any;
+    });
+
+    startSessionCleanup();
+    vi.advanceTimersByTime(30_000);
+
+    expect(logger.info).toHaveBeenCalledWith('[cleanup] Done — freed ~128K');
+  });
+
+  it('logs error when cleanup script fails', async () => {
+    vi.resetModules();
+    const { logger } = await import('./logger.js');
+    const { startSessionCleanup } = await import('./session-cleanup.js');
+
+    const err = new Error('script failed');
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      (cb as Function)(err, '');
+      return undefined as any;
+    });
+
+    startSessionCleanup();
+    vi.advanceTimersByTime(30_000);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      { err },
+      'Session cleanup failed',
+    );
+  });
+
+  it('does not log when stdout is empty', async () => {
+    vi.resetModules();
+    const { logger } = await import('./logger.js');
+    const { startSessionCleanup } = await import('./session-cleanup.js');
+
+    mockedExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      (cb as Function)(null, '');
+      return undefined as any;
+    });
+
+    startSessionCleanup();
+    vi.advanceTimersByTime(30_000);
+
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/src/session-cleanup.ts
+++ b/src/session-cleanup.ts
@@ -1,0 +1,25 @@
+import { execFile } from 'child_process';
+import path from 'path';
+
+import { logger } from './logger.js';
+
+const CLEANUP_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
+const SCRIPT_PATH = path.resolve(process.cwd(), 'scripts/cleanup-sessions.sh');
+
+function runCleanup(): void {
+  execFile('/bin/bash', [SCRIPT_PATH], { timeout: 60_000 }, (err, stdout) => {
+    if (err) {
+      logger.error({ err }, 'Session cleanup failed');
+      return;
+    }
+    const summary = stdout.trim().split('\n').pop();
+    if (summary) logger.info(summary);
+  });
+}
+
+export function startSessionCleanup(): void {
+  // Run once at startup (delayed 30s to not compete with init)
+  setTimeout(runCleanup, 30_000);
+  // Then every 24 hours
+  setInterval(runCleanup, CLEANUP_INTERVAL);
+}


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Main-branch audit comparing NanoPilot vs NanoClaw found 3 issues:

1. **CODEOWNERS** — Still referenced NanoClaw maintainers (`@gavrielc @gabi-simons`). Updated to `@ridermw`.
2. **Test label** — `setup/environment.test.ts` had "Anthropic credentials (regression)" in a test description. Renamed to "non-Copilot credentials (regression)". Test logic unchanged.
3. **Session cleanup** — NanoClaw has a session-cleanup utility that prunes stale disk artifacts. Ported and **rewritten** for NanoPilot paths:
   - Copilot session-state dirs (`data/sessions/{group}/.copilot/session-state/`) — 7 day retention, active sessions preserved
   - Copilot SDK process logs (`data/sessions/{group}/.copilot/logs/`) — 3 day retention
   - Container run logs (`groups/{group}/logs/`) — 7 day retention
   - Symlink safety guards (from eng review outside voice)
   - `sqlite3` existence check
   - `--dry-run` support

Also adds `TODOS.md` with 2 deferred items from the audit research spikes.

### Testing
- 5 new unit tests for `session-cleanup.ts` (timer setup, success logging, error logging, empty output)
- All 250 tests pass
- Typecheck clean, Prettier clean