### PR TITLE
fix: prioritize WebSearch/WebFetch over agent-browser + add smoke test

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -205,6 +205,13 @@ async function runQuery(
     }
   });
 
+  // Log tool usage for observability and E2E test assertions.
+  const unsubscribeTools = session.on('tool.execution_start', (event) => {
+    if (event.data?.toolName) {
+      log(`Tool: ${event.data.toolName}`);
+    }
+  });
+
   try {
     // sendAndWait blocks until the session is idle (turn complete).
     // Timeout is generous — agent may run complex multi-step tasks.
@@ -234,6 +241,7 @@ async function runQuery(
   } finally {
     ipcPolling = false;
     unsubscribe();
+    unsubscribeTools();
   }
 
   return { result: resultText, closedDuringQuery, bufferedMessages };

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -5,8 +5,8 @@ You are Nate, a personal assistant. You help with tasks, answer questions, and c
 ## What You Can Do
 
 - Answer questions and have conversations
-- **Search the web** with `web_search` — performs a Bing-powered search and returns results with snippets
-- **Fetch web pages** with `web_fetch` — retrieves page content as markdown or raw HTML from any URL
+- **Search the web** with `WebSearch` — performs a Bing-powered search and returns results with snippets
+- **Fetch web pages** with `WebFetch` — retrieves page content as markdown or raw HTML from any URL
 - **Interactive browsing** with `agent-browser` — for tasks that need clicking, filling forms, taking screenshots, or navigating SPAs (not needed for simple searches)
 - Read and write files in your workspace
 - Run bash commands in your sandbox
@@ -19,11 +19,11 @@ Use the right tool for the job:
 
 | Task | Tool | Example |
 |------|------|---------|
-| Search for information | `web_search` | Find recent news, look up topics, research products |
-| Read a specific URL | `web_fetch` | Read an article, check documentation, fetch API responses |
+| Search for information | `WebSearch` | Find recent news, look up topics, research products |
+| Read a specific URL | `WebFetch` | Read an article, check documentation, fetch API responses |
 | Interactive browsing | `agent-browser` | Fill forms, click buttons, take screenshots, navigate SPAs |
 
-**Default to `web_search`/`web_fetch`** — they're faster, more reliable, and don't require a browser. Only use `agent-browser` when you need to interact with page elements.
+**Default to `WebSearch`/`WebFetch`** — they're faster, more reliable, and don't require a browser. Only use `agent-browser` when you need to interact with page elements.
 
 ## Communication
 

--- a/groups/global/CLAUDE.md
+++ b/groups/global/CLAUDE.md
@@ -5,12 +5,25 @@ You are Nate, a personal assistant. You help with tasks, answer questions, and c
 ## What You Can Do
 
 - Answer questions and have conversations
-- Search the web and fetch content from URLs
-- **Browse the web** with `agent-browser` — open pages, click, fill forms, take screenshots, extract data (run `agent-browser open <url>` to start, then `agent-browser snapshot -i` to see interactive elements)
+- **Search the web** with `web_search` — performs a Bing-powered search and returns results with snippets
+- **Fetch web pages** with `web_fetch` — retrieves page content as markdown or raw HTML from any URL
+- **Interactive browsing** with `agent-browser` — for tasks that need clicking, filling forms, taking screenshots, or navigating SPAs (not needed for simple searches)
 - Read and write files in your workspace
 - Run bash commands in your sandbox
 - Schedule tasks to run later or on a recurring basis
 - Send messages back to the chat
+
+## Web Research
+
+Use the right tool for the job:
+
+| Task | Tool | Example |
+|------|------|---------|
+| Search for information | `web_search` | Find recent news, look up topics, research products |
+| Read a specific URL | `web_fetch` | Read an article, check documentation, fetch API responses |
+| Interactive browsing | `agent-browser` | Fill forms, click buttons, take screenshots, navigate SPAs |
+
+**Default to `web_search`/`web_fetch`** — they're faster, more reliable, and don't require a browser. Only use `agent-browser` when you need to interact with page elements.
 
 ## Communication
 

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -5,8 +5,8 @@ You are Nate, a personal assistant. You help with tasks, answer questions, and c
 ## What You Can Do
 
 - Answer questions and have conversations
-- **Search the web** with `web_search` — performs a Bing-powered search and returns results with snippets
-- **Fetch web pages** with `web_fetch` — retrieves page content as markdown or raw HTML from any URL
+- **Search the web** with `WebSearch` — performs a Bing-powered search and returns results with snippets
+- **Fetch web pages** with `WebFetch` — retrieves page content as markdown or raw HTML from any URL
 - **Interactive browsing** with `agent-browser` — for tasks that need clicking, filling forms, taking screenshots, or navigating SPAs (not needed for simple searches)
 - Read and write files in your workspace
 - Run bash commands in your sandbox
@@ -19,11 +19,11 @@ Use the right tool for the job:
 
 | Task | Tool | Example |
 |------|------|---------|
-| Search for information | `web_search` | Find recent news, look up topics, research products |
-| Read a specific URL | `web_fetch` | Read an article, check documentation, fetch API responses |
+| Search for information | `WebSearch` | Find recent news, look up topics, research products |
+| Read a specific URL | `WebFetch` | Read an article, check documentation, fetch API responses |
 | Interactive browsing | `agent-browser` | Fill forms, click buttons, take screenshots, navigate SPAs |
 
-**Default to `web_search`/`web_fetch`** — they're faster, more reliable, and don't require a browser. Only use `agent-browser` when you need to interact with page elements.
+**Default to `WebSearch`/`WebFetch`** — they're faster, more reliable, and don't require a browser. Only use `agent-browser` when you need to interact with page elements.
 
 ## Communication
 

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -5,12 +5,25 @@ You are Nate, a personal assistant. You help with tasks, answer questions, and c
 ## What You Can Do
 
 - Answer questions and have conversations
-- Search the web and fetch content from URLs
-- **Browse the web** with `agent-browser` — open pages, click, fill forms, take screenshots, extract data (run `agent-browser open <url>` to start, then `agent-browser snapshot -i` to see interactive elements)
+- **Search the web** with `web_search` — performs a Bing-powered search and returns results with snippets
+- **Fetch web pages** with `web_fetch` — retrieves page content as markdown or raw HTML from any URL
+- **Interactive browsing** with `agent-browser` — for tasks that need clicking, filling forms, taking screenshots, or navigating SPAs (not needed for simple searches)
 - Read and write files in your workspace
 - Run bash commands in your sandbox
 - Schedule tasks to run later or on a recurring basis
 - Send messages back to the chat
+
+## Web Research
+
+Use the right tool for the job:
+
+| Task | Tool | Example |
+|------|------|---------|
+| Search for information | `web_search` | Find recent news, look up topics, research products |
+| Read a specific URL | `web_fetch` | Read an article, check documentation, fetch API responses |
+| Interactive browsing | `agent-browser` | Fill forms, click buttons, take screenshots, navigate SPAs |
+
+**Default to `web_search`/`web_fetch`** — they're faster, more reliable, and don't require a browser. Only use `agent-browser` when you need to interact with page elements.
 
 ## Communication
 

--- a/test/e2e/live.test.ts
+++ b/test/e2e/live.test.ts
@@ -165,11 +165,11 @@ describeIf('E2E Live: Real Copilot agent session', () => {
     }
   }, 120_000);
 
-  it('agent uses web_search/web_fetch for web research (not agent-browser)', async () => {
+  it('agent uses WebSearch/WebFetch for web research (not agent-browser)', async () => {
     const dirs = createTestDirs(tempDir, 'websearch');
 
     const input = {
-      prompt: '<messages><message sender="TestUser" timestamp="2024-01-01T12:00:00Z">Search the web for "NanoClaw GitHub AI assistant" and tell me what you found. Use web_search, not agent-browser.</message></messages>',
+      prompt: '<messages><message sender="TestUser" timestamp="2024-01-01T12:00:00Z">Search the web for "NanoClaw GitHub AI assistant" and tell me what you found. Use WebSearch, not agent-browser.</message></messages>',
       groupFolder: 'websearch',
       chatJid: 'test:websearch-e2e',
       isMain: false,
@@ -187,12 +187,14 @@ describeIf('E2E Live: Real Copilot agent session', () => {
     // Tool usage assertions: stderr contains "Tool: <name>" lines from agent-runner
     const toolLines = stderr.split('\n').filter((l) => l.includes('Tool: '));
     const toolNames = toolLines.map((l) => l.match(/Tool: (.+)/)?.[1]?.trim()).filter(Boolean);
+    const toolNamesLower = toolNames.map((t) => t!.toLowerCase());
 
-    // Should have used web_search or web_fetch (built-in Copilot tools)
-    const usedWebTool = toolNames.some(
-      (t) => t === 'web_search' || t === 'web_fetch' || t === 'fetch_webpage',
+    // Should have used WebSearch/WebFetch (built-in Copilot tools)
+    // Tool names may appear as WebSearch/WebFetch or web_search/web_fetch depending on SDK version
+    const usedWebTool = toolNamesLower.some(
+      (t) => t === 'websearch' || t === 'webfetch' || t === 'web_search' || t === 'web_fetch' || t === 'fetch_webpage',
     );
-    expect(usedWebTool, `Expected web_search/web_fetch in tools used: [${toolNames.join(', ')}]`).toBe(true);
+    expect(usedWebTool, `Expected WebSearch/WebFetch in tools used: [${toolNames.join(', ')}]`).toBe(true);
 
     // Should NOT have launched agent-browser for a simple search
     const usedBrowser = toolNames.some(

--- a/test/e2e/live.test.ts
+++ b/test/e2e/live.test.ts
@@ -16,6 +16,96 @@ const CONTAINER_IMAGE = 'nanopilot-agent:latest';
 // Skip entire suite if no token
 const describeIf = GITHUB_TOKEN ? describe : describe.skip;
 
+/** Reusable container run result */
+interface ContainerResult {
+  stdout: string;
+  stderr: string;
+  output: { status: string; result: string | null; newSessionId?: string; error?: string };
+}
+
+/** Shared setup: temp dirs mimicking the container mount structure */
+function createTestDirs(baseTempDir: string, name: string, claudeMd?: string) {
+  const groupDir = path.join(baseTempDir, name);
+  const copilotDir = path.join(baseTempDir, `.copilot-${name}`);
+  const ipcDir = path.join(baseTempDir, `ipc-${name}`);
+  const globalDir = path.join(baseTempDir, `global-${name}`);
+  fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
+  fs.mkdirSync(copilotDir, { recursive: true });
+  fs.mkdirSync(path.join(ipcDir, 'messages'), { recursive: true });
+  fs.mkdirSync(path.join(ipcDir, 'tasks'), { recursive: true });
+  fs.mkdirSync(path.join(ipcDir, 'input'), { recursive: true });
+  fs.mkdirSync(globalDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(groupDir, 'CLAUDE.md'),
+    claudeMd ?? '# Test Agent\nYou are a test assistant. Reply concisely.',
+  );
+
+  // Mount the real global CLAUDE.md if it exists (tests shipped guidance)
+  const repoGlobalClaudeMd = path.resolve(__dirname, '../../groups/global/CLAUDE.md');
+  if (fs.existsSync(repoGlobalClaudeMd)) {
+    fs.copyFileSync(repoGlobalClaudeMd, path.join(globalDir, 'CLAUDE.md'));
+  }
+
+  return { groupDir, copilotDir, ipcDir, globalDir };
+}
+
+/** Spawn a container, pass input via stdin, return parsed output + stderr */
+async function runContainer(
+  input: Record<string, unknown>,
+  mounts: { groupDir: string; copilotDir: string; ipcDir: string; globalDir: string },
+  timeoutMs = 60_000,
+): Promise<ContainerResult> {
+  const containerName = `nanopilot-live-e2e-${Date.now()}`;
+  const args = [
+    'run', '-i', '--rm', '--name', containerName,
+    '-v', `${mounts.groupDir}:/workspace/group`,
+    '-v', `${mounts.copilotDir}:/home/node/.copilot`,
+    '-v', `${mounts.ipcDir}:/workspace/ipc`,
+    '-v', `${mounts.globalDir}:/workspace/global`,
+    CONTAINER_IMAGE,
+  ];
+
+  return new Promise<ContainerResult>((resolve, reject) => {
+    const proc = spawn('docker', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => { stdout += data.toString(); });
+    proc.stderr.on('data', (data) => { stderr += data.toString(); });
+
+    proc.stdin.write(JSON.stringify(input));
+    proc.stdin.end();
+
+    const timeout = setTimeout(() => {
+      try { execSync(`docker stop ${containerName}`, { stdio: 'pipe' }); } catch (_e) { /* stop may fail if container already exited */ }
+      reject(new Error(`Container timed out after ${timeoutMs}ms.\nStdout: ${stdout}\nStderr: ${stderr}`));
+    }, timeoutMs);
+
+    proc.on('close', (code) => {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        reject(new Error(`Container exited with code ${code}.\nStdout: ${stdout}\nStderr: ${stderr}`));
+        return;
+      }
+
+      // Parse output markers
+      const startMarker = '---NANOPILOT_OUTPUT_START---';
+      const endMarker = '---NANOPILOT_OUTPUT_END---';
+      const startIdx = stdout.indexOf(startMarker);
+      const endIdx = stdout.indexOf(endMarker);
+
+      if (startIdx === -1 || endIdx <= startIdx) {
+        reject(new Error(`Missing output markers.\nStdout: ${stdout}\nStderr: ${stderr}`));
+        return;
+      }
+
+      const jsonStr = stdout.slice(startIdx + startMarker.length, endIdx).trim();
+      const output = JSON.parse(jsonStr);
+      resolve({ stdout, stderr, output });
+    });
+  });
+}
+
 describeIf('E2E Live: Real Copilot agent session', () => {
   let tempDir: string;
 
@@ -23,8 +113,8 @@ describeIf('E2E Live: Real Copilot agent session', () => {
     // Verify container image exists
     try {
       execSync(`docker image inspect ${CONTAINER_IMAGE}`, { stdio: 'pipe' });
-    } catch {
-      throw new Error(`Container image ${CONTAINER_IMAGE} not found. Run ./container/build.sh first.`);
+    } catch (inspectErr) {
+      throw new Error(`Container image ${CONTAINER_IMAGE} not found. Run ./container/build.sh first.`, { cause: inspectErr });
     }
 
     // Create temp directory for test artifacts
@@ -38,148 +128,76 @@ describeIf('E2E Live: Real Copilot agent session', () => {
   });
 
   it('agent responds to a simple prompt', async () => {
-    // Create the required directory structure
-    const groupDir = path.join(tempDir, 'test-group');
-    const logsDir = path.join(groupDir, 'logs');
-    const copilotDir = path.join(tempDir, '.copilot');
-    const ipcDir = path.join(tempDir, 'ipc');
-    fs.mkdirSync(logsDir, { recursive: true });
-    fs.mkdirSync(copilotDir, { recursive: true });
-    fs.mkdirSync(path.join(ipcDir, 'messages'), { recursive: true });
-    fs.mkdirSync(path.join(ipcDir, 'tasks'), { recursive: true });
-    fs.mkdirSync(path.join(ipcDir, 'input'), { recursive: true });
+    const dirs = createTestDirs(tempDir, 'simple');
 
-    // Create CLAUDE.md for the agent
-    fs.writeFileSync(path.join(groupDir, 'CLAUDE.md'), '# Test Agent\nYou are a test assistant. Reply concisely.');
-
-    // Build ContainerInput
     const input = {
       prompt: '<messages><message sender="TestUser" timestamp="2024-01-01T12:00:00Z">Say exactly: PONG</message></messages>',
-      groupFolder: 'test-group',
+      groupFolder: 'simple',
       chatJid: 'test:live-e2e',
       isMain: false,
       assistantName: 'TestBot',
       githubToken: GITHUB_TOKEN,
     };
 
-    // Spawn container
-    const containerName = `nanopilot-live-e2e-${Date.now()}`;
-    const args = [
-      'run', '-i', '--rm', '--name', containerName,
-      '-v', `${groupDir}:/workspace/group`,
-      '-v', `${copilotDir}:/home/node/.copilot`,
-      '-v', `${ipcDir}:/workspace/ipc`,
-      CONTAINER_IMAGE,
-    ];
-
-    const result = await new Promise<string>((resolve, reject) => {
-      const proc = spawn('docker', args, { stdio: ['pipe', 'pipe', 'pipe'] });
-      let stdout = '';
-      let stderr = '';
-
-      proc.stdout.on('data', (data) => { stdout += data.toString(); });
-      proc.stderr.on('data', (data) => { stderr += data.toString(); });
-
-      proc.stdin.write(JSON.stringify(input));
-      proc.stdin.end();
-
-      const timeout = setTimeout(() => {
-        try { execSync(`docker stop ${containerName}`, { stdio: 'pipe' }); } catch {}
-        reject(new Error(`Container timed out after 60s.\nStdout: ${stdout}\nStderr: ${stderr}`));
-      }, 60_000);
-
-      proc.on('close', (code) => {
-        clearTimeout(timeout);
-        if (code !== 0) {
-          reject(new Error(`Container exited with code ${code}.\nStdout: ${stdout}\nStderr: ${stderr}`));
-          return;
-        }
-        resolve(stdout);
-      });
-    });
-
-    // Parse output — look for OUTPUT_MARKER pair
-    const startMarker = '---NANOPILOT_OUTPUT_START---';
-    const endMarker = '---NANOPILOT_OUTPUT_END---';
-    const startIdx = result.indexOf(startMarker);
-    const endIdx = result.indexOf(endMarker);
-
-    expect(startIdx).toBeGreaterThan(-1);
-    expect(endIdx).toBeGreaterThan(startIdx);
-
-    const jsonStr = result.slice(startIdx + startMarker.length, endIdx).trim();
-    const output = JSON.parse(jsonStr);
+    const { output } = await runContainer(input, dirs);
 
     expect(output.status).toBe('success');
     expect(output.result).toBeTruthy();
-    // The agent should respond with something containing PONG
-    expect(output.result.toUpperCase()).toContain('PONG');
-  }, 120_000); // 2 min timeout for the full test
+    expect(output.result!.toUpperCase()).toContain('PONG');
+  }, 120_000);
 
   it('agent handles session continuity', async () => {
-    // This test verifies that newSessionId is returned and can be reused
-    const groupDir = path.join(tempDir, 'session-test');
-    const copilotDir = path.join(tempDir, '.copilot-session');
-    const ipcDir = path.join(tempDir, 'ipc-session');
-    fs.mkdirSync(path.join(groupDir, 'logs'), { recursive: true });
-    fs.mkdirSync(copilotDir, { recursive: true });
-    fs.mkdirSync(path.join(ipcDir, 'messages'), { recursive: true });
-    fs.mkdirSync(path.join(ipcDir, 'tasks'), { recursive: true });
-    fs.mkdirSync(path.join(ipcDir, 'input'), { recursive: true });
-    fs.writeFileSync(path.join(groupDir, 'CLAUDE.md'), '# Test\nReply concisely.');
+    const dirs = createTestDirs(tempDir, 'session');
 
     const input = {
       prompt: '<messages><message sender="User" timestamp="2024-01-01T12:00:00Z">What is 2+2?</message></messages>',
-      groupFolder: 'session-test',
+      groupFolder: 'session',
       chatJid: 'test:session-e2e',
       isMain: false,
       githubToken: GITHUB_TOKEN,
     };
 
-    const containerName = `nanopilot-session-e2e-${Date.now()}`;
-    const args = [
-      'run', '-i', '--rm', '--name', containerName,
-      '-v', `${groupDir}:/workspace/group`,
-      '-v', `${copilotDir}:/home/node/.copilot`,
-      '-v', `${ipcDir}:/workspace/ipc`,
-      CONTAINER_IMAGE,
-    ];
+    const { output } = await runContainer(input, dirs);
 
-    const result = await new Promise<string>((resolve, reject) => {
-      const proc = spawn('docker', args, { stdio: ['pipe', 'pipe', 'pipe'] });
-      let stdout = '';
-      let stderr = '';
-      proc.stdout.on('data', (d) => { stdout += d.toString(); });
-      proc.stderr.on('data', (d) => { stderr += d.toString(); });
-      proc.stdin.write(JSON.stringify(input));
-      proc.stdin.end();
-      const t = setTimeout(() => {
-        try { execSync(`docker stop ${containerName}`, { stdio: 'pipe' }); } catch {}
-        reject(new Error(`Timeout.\nStdout: ${stdout}\nStderr: ${stderr}`));
-      }, 60_000);
-      proc.on('close', (code) => {
-        clearTimeout(t);
-        if (code !== 0) {
-          reject(new Error(`Container exited with code ${code}.\nStdout: ${stdout}\nStderr: ${stderr}`));
-          return;
-        }
-        resolve(stdout);
-      });
-    });
-
-    const startMarker = '---NANOPILOT_OUTPUT_START---';
-    const endMarker = '---NANOPILOT_OUTPUT_END---';
-    const startIdx = result.indexOf(startMarker);
-    const endIdx = result.indexOf(endMarker);
-
-    expect(startIdx).toBeGreaterThan(-1);
-    expect(endIdx).toBeGreaterThan(startIdx);
-
-    const output = JSON.parse(result.slice(startIdx + startMarker.length, endIdx).trim());
-    // If we got a session ID, verify it's a non-empty string
     if (output.newSessionId) {
       expect(typeof output.newSessionId).toBe('string');
       expect(output.newSessionId.length).toBeGreaterThan(0);
     }
   }, 120_000);
+
+  it('agent uses web_search/web_fetch for web research (not agent-browser)', async () => {
+    const dirs = createTestDirs(tempDir, 'websearch');
+
+    const input = {
+      prompt: '<messages><message sender="TestUser" timestamp="2024-01-01T12:00:00Z">Search the web for "NanoClaw GitHub AI assistant" and tell me what you found. Use web_search, not agent-browser.</message></messages>',
+      groupFolder: 'websearch',
+      chatJid: 'test:websearch-e2e',
+      isMain: false,
+      assistantName: 'TestBot',
+      githubToken: GITHUB_TOKEN,
+    };
+
+    const { output, stderr } = await runContainer(input, dirs, 90_000);
+
+    expect(output.status).toBe('success');
+    expect(output.result).toBeTruthy();
+    // Result should contain meaningful content, not an error or empty search
+    expect(output.result!.length).toBeGreaterThan(20);
+
+    // Tool usage assertions: stderr contains "Tool: <name>" lines from agent-runner
+    const toolLines = stderr.split('\n').filter((l) => l.includes('Tool: '));
+    const toolNames = toolLines.map((l) => l.match(/Tool: (.+)/)?.[1]?.trim()).filter(Boolean);
+
+    // Should have used web_search or web_fetch (built-in Copilot tools)
+    const usedWebTool = toolNames.some(
+      (t) => t === 'web_search' || t === 'web_fetch' || t === 'fetch_webpage',
+    );
+    expect(usedWebTool, `Expected web_search/web_fetch in tools used: [${toolNames.join(', ')}]`).toBe(true);
+
+    // Should NOT have launched agent-browser for a simple search
+    const usedBrowser = toolNames.some(
+      (t) => t?.includes('agent-browser') || t?.includes('Bash(agent-browser'),
+    );
+    expect(usedBrowser, `agent-browser should not be used for web search: [${toolNames.join(', ')}]`).toBe(false);
+  }, 180_000);
 });

--- a/test/e2e/live.test.ts
+++ b/test/e2e/live.test.ts
@@ -55,7 +55,8 @@ async function runContainer(
   mounts: { groupDir: string; copilotDir: string; ipcDir: string; globalDir: string },
   timeoutMs = 60_000,
 ): Promise<ContainerResult> {
-  const containerName = `nanopilot-live-e2e-${Date.now()}`;
+  const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const containerName = `nanopilot-live-e2e-${uniqueId}`;
   const args = [
     'run', '-i', '--rm', '--name', containerName,
     '-v', `${mounts.groupDir}:/workspace/group`,
@@ -100,8 +101,17 @@ async function runContainer(
       }
 
       const jsonStr = stdout.slice(startIdx + startMarker.length, endIdx).trim();
-      const output = JSON.parse(jsonStr);
-      resolve({ stdout, stderr, output });
+      try {
+        const output = JSON.parse(jsonStr);
+        resolve({ stdout, stderr, output });
+      } catch (parseErr) {
+        reject(new Error(
+          `Failed to parse container JSON output.\n` +
+          `Extracted JSON: ${jsonStr.slice(0, 500)}\n` +
+          `Stderr: ${stderr.slice(0, 500)}`,
+          { cause: parseErr },
+        ));
+      }
     });
   });
 }


### PR DESCRIPTION
## Problem

The agent uses `agent-browser` (headless Chromium) for simple web searches, which fails on search engines like DuckDuckGo due to anti-bot detection and JS-heavy rendering. The Copilot CLI has built-in `WebSearch` and `WebFetch` tools that are faster and more reliable.

## Changes

### Guidance (CLAUDE.md)
- Updated `groups/global/CLAUDE.md` and `groups/main/CLAUDE.md` to list `WebSearch`/`WebFetch` as primary web research tools
- Scoped `agent-browser` to interactive-only tasks (forms, screenshots, SPAs)
- Added **Web Research** section with tool selection guidance table

### Agent-runner (container code)
- Subscribe to `tool.execution_start` SDK events, logging tool names to stderr for observability and E2E test assertions

### E2E Tests
- Extracted reusable `createTestDirs()` + `runContainer()` helpers (reduced ~120 lines of duplication)
- New smoke test: verifies agent uses `WebSearch`/`WebFetch` (not `agent-browser`) for web research
- Mounts the real `groups/global/CLAUDE.md` so the test exercises shipped guidance
- `runContainer()` wraps JSON.parse in try/catch for robust error reporting
- Container names include random suffix to prevent collisions in parallel runs

## Impact

Guidance + runtime observability + regression test. No breaking changes.