### PR TITLE
docs: clarify cold-start vs hot-pipe message paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Single Node.js process. Channels self-register at startup. Messages queue per-gr
 
 Messages reach the agent via one of two paths:
 
-- **Cold start** — if no container is active for the group, the host spawns a fresh container with the batched prompt on stdin.
-- **Hot pipe** — if a container is already running for the group, the host writes a JSON file into its `/workspace/ipc/input/` directory and the in-container runner picks it up between or mid-turn. Containers stay alive until an idle timeout or a `_close` sentinel winds them down.
+- **Cold start** — if no container is active for the group, the host spawns a fresh container and delivers a full `ContainerInput` JSON payload on stdin, with the batched prompt included as one field.
+- **Hot pipe** — if a container is already running for the group, the host writes a JSON file to the per-group IPC input directory on the host (for example, `${DATA_DIR}/ipc/<groupFolder>/input`), which is mounted into the container at `/workspace/ipc/input/`. The in-container runner may drain those files while a turn is in progress, but buffered messages are prepended to the next prompt rather than acted on mid-turn. Containers stay alive until an idle timeout or a `_close` sentinel winds them down.
 
 ```
 Host                              Container

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Channels → SQLite → Polling Loop → Container (Copilot SDK) → Response
 
 Single Node.js process. Channels self-register at startup. Messages queue per-group. Agents run in isolated Linux containers via the Copilot SDK. IPC happens through the filesystem.
 
+Messages reach the agent via one of two paths:
+
+- **Cold start** — if no container is active for the group, the host spawns a fresh container with the batched prompt on stdin.
+- **Hot pipe** — if a container is already running for the group, the host writes a JSON file into its `/workspace/ipc/input/` directory and the in-container runner picks it up between or mid-turn. Containers stay alive until an idle timeout or a `_close` sentinel winds them down.
+
 ```
 Host                              Container
 ┌────────────────────┐            ┌──────────────────────────┐

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -85,6 +85,9 @@ A personal AI assistant accessible via messaging, with minimal custom code.
 - Only messages from registered groups are processed
 - Trigger: `@Andy` prefix (case insensitive), configurable via `ASSISTANT_NAME` env var
 - Unregistered groups are ignored completely
+- Messages reach the agent via one of two paths:
+  - **Cold start**: when no container is active for the group, the host spawns a fresh container with the batched prompt on stdin
+  - **Hot pipe**: when a container is already running, the host writes a JSON file into its per-group `/workspace/ipc/input/` directory and the in-container runner drains it between or mid-turn. A `_close` sentinel or idle timeout winds the container down.
 
 ### Memory System
 - **Per-group memory**: Each group has a folder with its own `CLAUDE.md`

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -86,8 +86,8 @@ A personal AI assistant accessible via messaging, with minimal custom code.
 - Trigger: `@Andy` prefix (case insensitive), configurable via `ASSISTANT_NAME` env var
 - Unregistered groups are ignored completely
 - Messages reach the agent via one of two paths:
-  - **Cold start**: when no container is active for the group, the host spawns a fresh container with the batched prompt on stdin
-  - **Hot pipe**: when a container is already running, the host writes a JSON file into its per-group `/workspace/ipc/input/` directory and the in-container runner drains it between or mid-turn. A `_close` sentinel or idle timeout winds the container down.
+  - **Cold start**: when no container is active for the group, the host spawns a fresh container and sends a full `ContainerInput` JSON payload on stdin, with the batched prompt included as one field
+  - **Hot pipe**: when a container is already running, the host writes a JSON file to the per-group IPC input directory on the host (e.g. `${DATA_DIR}/ipc/<groupFolder>/input`), which is mounted into the container at `/workspace/ipc/input/`. The in-container runner may drain those files while a turn is in progress, but buffered messages are prepended to the next prompt rather than acted on mid-turn. A `_close` sentinel or idle timeout winds the container down.
 
 ### Memory System
 - **Per-group memory**: Each group has a folder with its own `CLAUDE.md`


### PR DESCRIPTION
## What

Adds a short explanation of the two paths a message can take to reach the agent to both `README.md` (under "How It Works") and `docs/REQUIREMENTS.md` (under "Message Routing"):

- **Cold start** — no active container → host spawns a fresh container with the batched prompt on stdin.
- **Hot pipe** — container already running → host writes a JSON file into the group's `/workspace/ipc/input/` directory and the in-container runner drains it between or mid-turn.

## Why

The existing docs describe message flow as a single pipeline, but the code in `src/index.ts` (`processGroupMessages` vs `startMessageLoop` + `GroupQueue.sendMessage`) and `container/agent-runner/src/index.ts` (`drainIpcInput` / `_close` sentinel) has two distinct paths. Without this note, a reader has to trace `GroupQueue`, the IPC directory layout, and the container's polling loop to understand how follow-up messages reach a live agent.

## How it was tested

Docs-only change. Verified rendered Markdown locally.